### PR TITLE
Scaffold repository for OpenTTD 14.1 client port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+/build/
+/.vs/
+/.vscode/
+CMakeCache.txt
+CMakeFiles/
+*.sln
+*.vcxproj*
+compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.21)
+project(SimpleOpenTTDClient LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+option(SOTC_BUILD_TESTS "Build unit tests" OFF)
+
+add_library(project_warnings INTERFACE)
+if(MSVC)
+    target_compile_options(project_warnings INTERFACE
+        /W4
+        /permissive-
+        /WX-)
+else()
+    target_compile_options(project_warnings INTERFACE
+        -Wall
+        -Wextra
+        -Wpedantic)
+endif()
+
+add_subdirectory(src)
+
+if(SOTC_BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
+endif()

--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# Simple OpenTTD Client
+
+This repository aims to provide a modernized fork of the `cmclient` project that is compatible with OpenTTD 14.1. The initial goal is to scaffold the project structure, document the required work, and prepare a build system that targets Windows (MSVC) and Linux.
+
+## Project Goals
+- Maintain feature parity with the original `cmclient` where possible.
+- Ensure compatibility with OpenTTD 14.1 network and gameplay features.
+- Provide straightforward build and packaging instructions for Windows.
+
+## Repository Layout
+- `cmake/` – CMake toolchain helpers and platform specific configuration.
+- `external/` – Third-party dependencies (as Git submodules or source drops).
+- `src/` – Client implementation sources.
+- `include/` – Public headers.
+- `docs/` – Design documents and migration notes.
+- `tools/` – Developer utilities and scripts.
+
+## Current Status
+The project is currently a scaffold. See `docs/ROADMAP.md` for the implementation plan and `docs/REFERENCES.md` for collected research material on the legacy client and OpenTTD 14.1 APIs.
+
+## Building (WIP)
+```bash
+cmake -S . -B build
+cmake --build build
+```
+
+Windows builds are not yet configured; once CI is in place, instructions for MSVC will be added.
+
+## Contributing
+1. Fork and clone the repository.
+2. Configure dependencies (see `docs/DEPENDENCIES.md`).
+3. Implement features or fixes.
+4. Submit a pull request with a detailed description and testing evidence.
+
+## License
+This project is licensed under the MIT License. See `LICENSE` for details.

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -1,0 +1,20 @@
+# Dependencies (Draft)
+
+The final client will depend on the following third-party libraries. Versions will be confirmed during the implementation phase.
+
+| Library | Purpose | Notes |
+| --- | --- | --- |
+| SDL2 | Rendering / input | Required for cross-platform windowing and input handling. |
+| SDL2_image | Image loading | For sprite assets used in the client UI. |
+| SDL2_ttf | Font rendering | For UI text. |
+| libcurl | HTTP(S) communication | For remote configuration and update checks. |
+| zlib | Compression | Used by the OpenTTD network protocol. |
+| OpenSSL | TLS support | Optional, required for secure connections if supported. |
+| spdlog | Logging | Structured logging output. |
+
+## Dependency Management Options
+1. **vcpkg:** Integrate via the `CMAKE_TOOLCHAIN_FILE` for Windows-centric workflows.
+2. **FetchContent:** Use CMake's built-in module to download and build dependencies during configure time.
+3. **Git Submodules:** Vendor exact versions for deterministic builds.
+
+A decision will be made after evaluating CI constraints and developer ergonomics.

--- a/docs/REFERENCES.md
+++ b/docs/REFERENCES.md
@@ -1,0 +1,20 @@
+# References
+
+A curated list of resources relevant to porting `cmclient` to OpenTTD 14.1.
+
+## Upstream Projects
+- [`cmclient` on GitHub](https://github.com/citymania-org/cmclient)
+- [OpenTTD upstream repository](https://github.com/OpenTTD/OpenTTD)
+
+## OpenTTD Protocol & API
+- [Network protocol documentation](https://wiki.openttd.org/en/Development/Network)
+- [Game script API](https://wiki.openttd.org/en/Development/Game%20Script)
+- [Settings and configuration formats](https://wiki.openttd.org/en/Manual/Settings)
+
+## Build & Tooling
+- [CMake documentation](https://cmake.org/documentation/)
+- [vcpkg package manager](https://vcpkg.io/en/index.html)
+- [GitHub Actions for C++](https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-c-plus-plus)
+
+## Migration Notes
+Detailed migration notes will be captured in dedicated documents under `docs/` as the port progresses.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,29 @@
+# Roadmap
+
+This document tracks the work required to deliver a modernized OpenTTD client derived from `cmclient`.
+
+## Phase 0 – Research & Planning (Current)
+- [x] Establish repository scaffold and documentation structure.
+- [ ] Inventory `cmclient` architecture (modules, dependencies, build system).
+- [ ] Map OpenTTD 14.1 protocol and API deltas compared to the version targeted by `cmclient`.
+- [ ] Decide on dependency management (vendored, submodules, package manager).
+
+## Phase 1 – Build System & Tooling
+- [ ] Create CMake-based build configuration for Windows (MSVC) and Linux.
+- [ ] Integrate vcpkg or FetchContent for dependencies (SDL2, libcurl, zlib, etc.).
+- [ ] Set up continuous integration for Windows and Linux builds.
+- [ ] Provide developer setup scripts and documentation.
+
+## Phase 2 – Core Client Port
+- [ ] Port networking layer to OpenTTD 14.1 protocol changes.
+- [ ] Update serialization/deserialization logic.
+- [ ] Implement GUI adjustments for new features.
+- [ ] Ensure compatibility with dedicated server management tools.
+
+## Phase 3 – Quality Assurance & Release
+- [ ] Automated regression tests against OpenTTD 14.1 server.
+- [ ] Manual gameplay testing checklist.
+- [ ] Package Windows binaries (installer/ZIP).
+- [ ] Draft release notes and user documentation.
+
+Progress will be tracked via GitHub issues and milestone boards once the repository is published.

--- a/include/client_app.hpp
+++ b/include/client_app.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace sotc {
+
+struct LaunchOptions {
+    std::string server_host;
+    int server_port{3979};
+    std::string player_name;
+    bool headless{false};
+};
+
+class ClientApp {
+public:
+    ClientApp();
+
+    void configure(LaunchOptions options);
+
+    [[nodiscard]] const LaunchOptions &options() const noexcept { return options_; }
+
+    void run();
+
+private:
+    LaunchOptions options_{};
+    void log_startup_info() const;
+};
+
+std::vector<std::string> discover_local_servers();
+
+} // namespace sotc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,22 @@
+add_library(sotc_core STATIC
+    client_app.cpp
+)
+
+target_include_directories(sotc_core
+    PUBLIC
+        ${CMAKE_SOURCE_DIR}/include
+)
+
+target_link_libraries(sotc_core
+    PRIVATE
+        project_warnings
+)
+
+add_executable(sotc
+    main.cpp
+)
+
+target_link_libraries(sotc
+    PRIVATE
+        sotc_core
+)

--- a/src/client_app.cpp
+++ b/src/client_app.cpp
@@ -1,0 +1,47 @@
+#include "client_app.hpp"
+
+#include <chrono>
+#include <iostream>
+#include <thread>
+
+namespace sotc {
+
+ClientApp::ClientApp() = default;
+
+void ClientApp::configure(LaunchOptions options) {
+    options_ = std::move(options);
+}
+
+void ClientApp::run() {
+    log_startup_info();
+    std::cout << "Simple OpenTTD Client scaffold running." << std::endl;
+    std::cout << "Networking and rendering subsystems are not yet implemented." << std::endl;
+
+    if (options_.headless) {
+        std::cout << "Headless mode enabled; exiting immediately." << std::endl;
+        return;
+    }
+
+    using namespace std::chrono_literals;
+    std::cout << "Simulating main loop (press Ctrl+C to exit)." << std::endl;
+    for (int i = 0; i < 5; ++i) {
+        std::this_thread::sleep_for(200ms);
+        std::cout << "." << std::flush;
+    }
+    std::cout << std::endl;
+}
+
+void ClientApp::log_startup_info() const {
+    std::cout << "Launching client with configuration:\n";
+    std::cout << "  Server: " << (options_.server_host.empty() ? "<not set>" : options_.server_host)
+              << ':' << options_.server_port << '\n';
+    std::cout << "  Player: " << (options_.player_name.empty() ? "<anonymous>" : options_.player_name) << '\n';
+    std::cout << "  Headless: " << (options_.headless ? "yes" : "no") << std::endl;
+}
+
+std::vector<std::string> discover_local_servers() {
+    std::cout << "Server discovery is not implemented yet." << std::endl;
+    return {};
+}
+
+} // namespace sotc

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,18 @@
+#include "client_app.hpp"
+
+#include <iostream>
+
+int main(int argc, char **argv) {
+    sotc::LaunchOptions options{};
+    if (argc > 1) {
+        options.server_host = argv[1];
+    }
+    if (argc > 2) {
+        options.player_name = argv[2];
+    }
+
+    sotc::ClientApp app;
+    app.configure(options);
+    app.run();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- set up a CMake-based C++ project skeleton for the future client, including warning flags and modular targets
- document the project roadmap, dependencies, and reference materials to guide the porting effort
- implement placeholder client application classes and entry point to exercise the build pipeline

## Testing
- cmake -S . -B build
- cmake --build build


------
https://chatgpt.com/codex/tasks/task_e_68dc2194b6f88321898d5c15cc26dd94