### PR TITLE
Document dependency management plan

### DIFF
--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -17,4 +17,14 @@ The final client will depend on the following third-party libraries. Versions wi
 2. **FetchContent:** Use CMake's built-in module to download and build dependencies during configure time.
 3. **Git Submodules:** Vendor exact versions for deterministic builds.
 
-A decision will be made after evaluating CI constraints and developer ergonomics.
+## Decision
+We will adopt a **vcpkg manifest-based workflow** as the primary dependency manager. The
+project will ship a `vcpkg.json` manifest that pins library versions and enables
+deterministic binary caching in CI. Platform-specific triplets will cover MSVC and
+GCC/Clang targets so that developers can bootstrap a working toolchain with a single
+`vcpkg install` step.
+
+For libraries that are not available in the public vcpkg registry, we will maintain
+overlay ports inside the repository. Small, header-only utilities may still be
+integrated with CMake `FetchContent` when doing so avoids unnecessary rebuilds or
+packaging complexity, but vcpkg remains the source of truth for version locking.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,7 +6,7 @@ This document tracks the work required to deliver a modernized OpenTTD client de
 - [x] Establish repository scaffold and documentation structure.
 - [x] Inventory `cmclient` architecture (modules, dependencies, build system).
 - [x] Map OpenTTD 14.1 protocol and API deltas compared to the version targeted by `cmclient`.
-- [ ] Decide on dependency management (vendored, submodules, package manager).
+- [x] Decide on dependency management (vcpkg manifest with overlay ports, FetchContent for small header-only libs).
 
 ## Phase 1 – Build System & Tooling
 - [ ] Create CMake-based build configuration for Windows (MSVC) and Linux.


### PR DESCRIPTION
## Summary
- document the decision to standardize on a vcpkg manifest workflow with overlay ports for missing libraries
- note the dependency management decision completion in the Phase 0 roadmap checklist

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc26e47dc8832199e0afbb7f3c6627