### PR TITLE
Add Windows and Linux aware CMake configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,23 +1,62 @@
 cmake_minimum_required(VERSION 3.21)
-project(SimpleOpenTTDClient LANGUAGES CXX)
+
+project(SimpleOpenTTDClient VERSION 0.1.0 LANGUAGES CXX)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
+endif()
+
 option(SOTC_BUILD_TESTS "Build unit tests" OFF)
+option(SOTC_ENABLE_IPO "Enable interprocedural optimisation when supported" OFF)
+
+include(GNUInstallDirs)
+include(CMakePrintHelpers OPTIONAL)
+include(CheckCXXCompilerFlag OPTIONAL)
+include(SOTCCompilerWarnings)
 
 add_library(project_warnings INTERFACE)
+sotc_set_project_warnings(project_warnings)
+
+add_library(project_options INTERFACE)
+
 if(MSVC)
-    target_compile_options(project_warnings INTERFACE
-        /W4
+    target_compile_definitions(project_options INTERFACE
+        _CRT_SECURE_NO_WARNINGS
+        WIN32_LEAN_AND_MEAN
+        NOMINMAX
+    )
+    target_compile_options(project_options INTERFACE
         /permissive-
-        /WX-)
+        /Zc:__cplusplus
+        /Zc:preprocessor
+    )
 else()
-    target_compile_options(project_warnings INTERFACE
-        -Wall
-        -Wextra
-        -Wpedantic)
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        target_compile_options(project_options INTERFACE -fcolor-diagnostics)
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        target_compile_options(project_options INTERFACE -fdiagnostics-color=always)
+    endif()
+
+    find_package(Threads REQUIRED)
+    target_link_libraries(project_options INTERFACE Threads::Threads)
+endif()
+
+if(SOTC_ENABLE_IPO)
+    include(CheckIPOSupported)
+    check_ipo_supported(RESULT ipo_supported OUTPUT ipo_output)
+    if(ipo_supported)
+        set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
+    else()
+        message(WARNING "IPO is not supported by the current toolchain: ${ipo_output}")
+    endif()
 endif()
 
 add_subdirectory(src)

--- a/README.md
+++ b/README.md
@@ -18,13 +18,24 @@ This repository aims to provide a modernized fork of the `cmclient` project that
 ## Current Status
 The project is currently a scaffold. See `docs/ROADMAP.md` for the implementation plan, `docs/REFERENCES.md` for collected research material, and `docs/OPEN_TTD_PROTOCOL_DELTAS.md` for a breakdown of the networking differences between OpenTTD 1.10.x and 14.1.
 
-## Building (WIP)
+## Building
+The project uses CMake 3.21 or newer. Out-of-tree builds are recommended to keep generated artefacts separate from the source tree.
+
+### Linux (GCC/Clang)
 ```bash
-cmake -S . -B build
-cmake --build build
+cmake -S . -B build/linux -G Ninja
+cmake --build build/linux
 ```
 
-Windows builds are not yet configured; once CI is in place, instructions for MSVC will be added.
+The configuration enables POSIX threads automatically. Enable IPO/LTO with `-DSOTC_ENABLE_IPO=ON` when supported by your toolchain.
+
+### Windows (MSVC)
+```powershell
+cmake -S . -B build\msvc -G "Visual Studio 17 2022" -A x64
+cmake --build build\msvc --config Release
+```
+
+The generated Visual Studio solution configures common warnings and disables legacy CRT deprecation noise. You can enable IPO with `/p:SOTC_ENABLE_IPO=ON` or set the option from the CMake GUI.
 
 ## Contributing
 1. Fork and clone the repository.

--- a/cmake/SOTCCompilerWarnings.cmake
+++ b/cmake/SOTCCompilerWarnings.cmake
@@ -1,0 +1,39 @@
+function(sotc_set_project_warnings target)
+    if(MSVC)
+        target_compile_options(${target} INTERFACE
+            /W4
+            /w14242 # conversion, possible loss of data
+            /w14254 # conversion, possible loss of data
+            /w14263 # member function does not override any base class virtual member function
+            /w14265 # class has virtual functions, but destructor is not virtual
+            /w14287 # unsigned/negative constant mismatch
+            /we4289 # loop control variable used outside for-loop scope
+            /wd4345 # behavior change: an object is allocated on the heap
+            /w14296 # expression is always true
+            /w14311 # pointer truncation from 'type1' to 'type2'
+            /w14545 # expression before comma has no effect; expected expression with side-effect
+            /w14546 # function call before comma missing argument list
+            /w14547 # operator before comma has no effect; expected operator with side-effect
+            /w14549 # operator before comma has no effect; expected operator with side-effect
+            /w14555 # expression has no effect; expected expression with side-effect
+            /w14619 # pragma warning(pop) : file(s) not found
+            /w14905 # wide string literal cast to 'LPSTR'
+            /w14906 # string literal cast to 'LPWSTR'
+            /w14928 # illegal copy-initialization; more than one user-defined conversion has been implicitly applied
+            /permissive-
+            /EHsc
+        )
+    else()
+        target_compile_options(${target} INTERFACE
+            -Wall
+            -Wextra
+            -Wpedantic
+            -Wshadow
+            -Wconversion
+            -Wsign-conversion
+            -Wdouble-promotion
+            -Wformat=2
+            -Wimplicit-fallthrough
+        )
+    endif()
+endfunction()

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,7 +9,7 @@ This document tracks the work required to deliver a modernized OpenTTD client de
 - [x] Decide on dependency management (vcpkg manifest with overlay ports, FetchContent for small header-only libs).
 
 ## Phase 1 – Build System & Tooling
-- [ ] Create CMake-based build configuration for Windows (MSVC) and Linux.
+- [x] Create CMake-based build configuration for Windows (MSVC) and Linux.
 - [ ] Integrate vcpkg or FetchContent for dependencies (SDL2, libcurl, zlib, etc.).
 - [ ] Set up continuous integration for Windows and Linux builds.
 - [ ] Provide developer setup scripts and documentation.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,7 +8,8 @@ target_include_directories(sotc_core
 )
 
 target_link_libraries(sotc_core
-    PRIVATE
+    PUBLIC
+        project_options
         project_warnings
 )
 


### PR DESCRIPTION
## Summary
- add platform-aware project options and warning configuration for the CMake build
- provide a reusable compiler warning module and propagate options to all targets
- document Linux and MSVC build workflows and update the roadmap checklist

## Testing
- cmake -S . -B build
- cmake --build build

------
https://chatgpt.com/codex/tasks/task_e_68dc27e73d44832189bb6e0acaa14cd6