### PR TITLE
Add GitHub Actions CI for Windows and Linux builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup vcpkg
+        uses: microsoft/setup-vcpkg@v1
+        with:
+          vcpkgJsonDir: ${{ github.workspace }}
+
+      - name: Configure CMake
+        shell: bash
+        run: |
+          cmake -S . -B build \
+            -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
+
+      - name: Build
+        shell: bash
+        run: cmake --build build --config Release

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -11,7 +11,7 @@ This document tracks the work required to deliver a modernized OpenTTD client de
 ## Phase 1 – Build System & Tooling
 - [x] Create CMake-based build configuration for Windows (MSVC) and Linux.
 - [x] Integrate vcpkg or FetchContent for dependencies (SDL2, libcurl, zlib, etc.).
-- [ ] Set up continuous integration for Windows and Linux builds.
+- [x] Set up continuous integration for Windows and Linux builds.
 - [ ] Provide developer setup scripts and documentation.
 
 ## Phase 2 – Core Client Port


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that configures vcpkg and builds the project on Ubuntu and Windows
- mark the roadmap item for cross-platform CI as complete

## Testing
- not run (workflow definition only)


------
https://chatgpt.com/codex/tasks/task_e_68dc2cbbdbac83218465d94a4b5b09b5