### PR TITLE
Update CI vcpkg setup action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,15 +18,16 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup vcpkg
-        uses: microsoft/setup-vcpkg@v1
+        id: vcpkg
+        uses: lukka/run-vcpkg@v11
         with:
-          vcpkgJsonDir: ${{ github.workspace }}
+          vcpkgJsonGlob: vcpkg.json
 
       - name: Configure CMake
         shell: bash
         run: |
           cmake -S . -B build \
-            -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
+            -DCMAKE_TOOLCHAIN_FILE="${{ steps.vcpkg.outputs.RUNVCPKG_VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake"
 
       - name: Build
         shell: bash


### PR DESCRIPTION
## Summary
- replace the deprecated microsoft/setup-vcpkg action with lukka/run-vcpkg and give the step an id
- configure CMake to use the toolchain file exported by the updated vcpkg action

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68dc323e436c8321be31d9b2abae00fe