### PR TITLE
Use VCPKG_ROOT in CI toolchain configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         shell: bash
         run: |
           cmake -S . -B build \
-            -DCMAKE_TOOLCHAIN_FILE="${{ steps.vcpkg.outputs.RUNVCPKG_VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake"
+            -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
 
       - name: Build
         shell: bash


### PR DESCRIPTION
## Summary
- update the CI workflow to rely on the VCPKG_ROOT environment variable when configuring CMake

## Testing
- not run (CI workflow)

------
https://chatgpt.com/codex/tasks/task_e_68dc345aa4f883218de26d0af9a7a085