### PR TITLE
Adjust Windows CI to use PowerShell for CMake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,26 @@ jobs:
         with:
           vcpkgJsonGlob: vcpkg.json
 
-      - name: Configure CMake
+      - name: Configure CMake (Unix)
+        if: matrix.os != 'windows-latest'
         shell: bash
         run: |
           cmake -S . -B build \
             -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
 
-      - name: Build
+      - name: Configure CMake (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: >-
+          cmake -S . -B build -G "Visual Studio 17 2022"
+          -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
+
+      - name: Build (Unix)
+        if: matrix.os != 'windows-latest'
         shell: bash
+        run: cmake --build build --config Release
+
+      - name: Build (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
         run: cmake --build build --config Release


### PR DESCRIPTION
## Summary
- split the configure and build steps for Windows to run under PowerShell
- specify the Visual Studio 2022 generator when configuring on Windows

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68dc3930287c832190040e866c9bde9a