### PR TITLE
Ensure Ubuntu CI installs autotools prerequisites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,12 @@ jobs:
         with:
           vcpkgJsonGlob: vcpkg.json
 
+      - name: Install autotools dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends autoconf automake libtool libltdl-dev gettext pkg-config python3-jinja2
+
       - name: Configure CMake
         shell: bash
         run: |


### PR DESCRIPTION
## Summary
- add an Ubuntu-specific workflow step that installs autotools and related packages required for vcpkg ports that call autoreconf.

## Testing
- `cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake`


------
https://chatgpt.com/codex/tasks/task_e_68dc392eca3083218241746f4a5bad1a