### PR TITLE
Add developer setup documentation and vcpkg bootstrap scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,21 @@ This repository aims to provide a modernized fork of the `cmclient` project that
 ## Current Status
 The project is currently a scaffold. See `docs/ROADMAP.md` for the implementation plan, `docs/REFERENCES.md` for collected research material, and `docs/OPEN_TTD_PROTOCOL_DELTAS.md` for a breakdown of the networking differences between OpenTTD 1.10.x and 14.1.
 
+## Developer Setup
+For a guided walkthrough of the toolchain requirements and helper scripts, see [docs/DEVELOPER_SETUP.md](docs/DEVELOPER_SETUP.md).
+
+Quick start for Unix-like environments:
+
+```bash
+./tools/bootstrap_vcpkg.sh
+```
+
+On Windows, run the PowerShell helper:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\tools\bootstrap_vcpkg.ps1
+```
+
 ## Building
 The project uses CMake 3.21 or newer. Out-of-tree builds are recommended to keep generated artefacts separate from the source tree.
 

--- a/docs/DEVELOPER_SETUP.md
+++ b/docs/DEVELOPER_SETUP.md
@@ -1,0 +1,89 @@
+# Developer Setup
+
+This guide explains how to bootstrap the Simple OpenTTD Client development
+environment on Linux, macOS, and Windows. The scripts in `tools/` automate the
+vcpkg checkout that provides the project's third-party dependencies.
+
+## Prerequisites
+- Git 2.40 or newer.
+- CMake 3.21+ with the Ninja generator (recommended) or your preferred build
+  system.
+- A C++20-capable compiler:
+  - GCC 11+ or Clang 13+ on Linux and macOS.
+  - Visual Studio 2022 on Windows.
+- Python 3.9+ for auxiliary scripts.
+
+> **Note**
+> The repository does not bundle the vcpkg submodule. The scripts below clone
+> the upstream repository into a local folder so that developers can manage
+> updates independently.
+
+## Bootstrapping vcpkg (Linux/macOS)
+
+From the repository root, run:
+
+```bash
+./tools/bootstrap_vcpkg.sh
+```
+
+The script performs the following actions:
+
+1. Clones the official `microsoft/vcpkg` repository into `./.vcpkg` (or the
+   location defined via `VCPKG_ROOT`).
+2. Runs `bootstrap-vcpkg.sh -disableMetrics` to produce the `vcpkg` binary.
+3. Installs the dependencies declared in `vcpkg.json` for the detected host
+   triplet (defaults to `x64-linux`).
+
+Additional options:
+
+- `./tools/bootstrap_vcpkg.sh --directory /path/to/vcpkg` – clone vcpkg into a
+  custom directory.
+- `./tools/bootstrap_vcpkg.sh --triplet x64-linux --triplet x64-osx` – install
+  libraries for multiple triplets in one pass.
+- `./tools/bootstrap_vcpkg.sh --no-install` – skip the dependency installation
+  step if you only need a bootstrapped checkout.
+
+After the script finishes, export `VCPKG_ROOT` so CMake can locate the
+manifest-based toolchain:
+
+```bash
+export VCPKG_ROOT="$(pwd)/.vcpkg"
+```
+
+Consider adding this line to your shell profile for persistence.
+
+## Bootstrapping vcpkg (Windows)
+
+Open a PowerShell prompt with the necessary execution policy (e.g.
+`Set-ExecutionPolicy -Scope CurrentUser RemoteSigned`) and run:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\tools\bootstrap_vcpkg.ps1
+```
+
+The PowerShell script mirrors the behaviour of the Bash helper by cloning
+vcpkg, bootstrapping the executable, and installing dependencies for the
+`x64-windows` triplet by default. Pass `-Triplet x64-windows-static` to install
+additional variants or `-NoInstall` to skip the install step entirely.
+
+Once complete, set the environment variable so that future shells and CMake
+runs pick up the manifest automatically:
+
+```powershell
+$env:VCPKG_ROOT = "${PWD}\.vcpkg"
+```
+
+To persist the setting, add the line above to your PowerShell profile (run
+`notepad $PROFILE` to edit it).
+
+## Next Steps
+
+With vcpkg configured you can proceed to configure the build. Example commands
+are available in the project `README.md`. On first configure, CMake will reuse
+any libraries already installed via the manifest. If you wish to keep
+artefacts separate, use out-of-tree build directories such as `build/linux` or
+`build/msvc`.
+
+If you encounter issues with vcpkg integration, consult the official
+[documentation](https://learn.microsoft.com/vcpkg/) or inspect the
+`vcpkg.json` manifest in this repository for the full dependency list.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -12,7 +12,7 @@ This document tracks the work required to deliver a modernized OpenTTD client de
 - [x] Create CMake-based build configuration for Windows (MSVC) and Linux.
 - [x] Integrate vcpkg or FetchContent for dependencies (SDL2, libcurl, zlib, etc.).
 - [x] Set up continuous integration for Windows and Linux builds.
-- [ ] Provide developer setup scripts and documentation.
+- [x] Provide developer setup scripts and documentation.
 
 ## Phase 2 – Core Client Port
 - [ ] Port networking layer to OpenTTD 14.1 protocol changes.

--- a/tools/bootstrap_vcpkg.ps1
+++ b/tools/bootstrap_vcpkg.ps1
@@ -1,0 +1,59 @@
+param(
+    [string]$Directory = $env:VCPKG_ROOT,
+    [string[]]$Triplet,
+    [switch]$NoInstall
+)
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+if (-not $Directory) {
+    $Directory = Join-Path $repoRoot '.vcpkg'
+}
+
+$parent = Split-Path -Parent $Directory
+if ($parent) {
+    $null = New-Item -ItemType Directory -Path $parent -Force
+}
+
+$gitDir = Join-Path $Directory '.git'
+if (-not (Test-Path $gitDir)) {
+    Write-Host "Cloning vcpkg into $Directory"
+    git clone https://github.com/microsoft/vcpkg.git $Directory
+} else {
+    Write-Host "Updating existing vcpkg checkout in $Directory"
+    git -C $Directory pull --ff-only
+}
+
+$vcpkgExe = Join-Path $Directory 'vcpkg.exe'
+if (-not (Test-Path $vcpkgExe)) {
+    Write-Host 'Bootstrapping vcpkg'
+    $bootstrapBat = Join-Path $Directory 'bootstrap-vcpkg.bat'
+    $bootstrapSh = Join-Path $Directory 'bootstrap-vcpkg.sh'
+    if (Test-Path $bootstrapBat) {
+        & $bootstrapBat -disableMetrics
+    } elseif (Test-Path $bootstrapSh) {
+        & $bootstrapSh -disableMetrics
+    } else {
+        throw "Unable to locate vcpkg bootstrap script in $Directory"
+    }
+} else {
+    Write-Host 'vcpkg already bootstrapped'
+}
+
+if (-not (Test-Path $vcpkgExe)) {
+    $vcpkgExe = Join-Path $Directory 'vcpkg'
+}
+if (-not (Test-Path $vcpkgExe)) {
+    throw "Unable to find vcpkg executable in $Directory"
+}
+
+if (-not $NoInstall) {
+    if (-not $Triplet -or $Triplet.Count -eq 0) {
+        $Triplet = @('x64-windows')
+    }
+    foreach ($t in $Triplet) {
+        Write-Host "Installing dependencies for triplet: $t"
+        & $vcpkgExe install --triplet $t
+    }
+}
+
+Write-Host "All done. Set VCPKG_ROOT to $Directory or add it to your profile."

--- a/tools/bootstrap_vcpkg.sh
+++ b/tools/bootstrap_vcpkg.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+print_usage() {
+  cat <<'USAGE'
+Usage: bootstrap_vcpkg.sh [options]
+
+Options:
+  -d, --directory PATH  Destination for the vcpkg checkout. Defaults to <repo>/.vcpkg or $VCPKG_ROOT when set.
+  -t, --triplet NAME    vcpkg triplet to install (e.g. x64-linux, x64-windows). May be repeated. Defaults to host triplet.
+      --no-install      Skip dependency installation and only ensure vcpkg is bootstrapped.
+  -h, --help            Show this message and exit.
+USAGE
+}
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+default_vcpkg_dir="${VCPKG_ROOT:-"$repo_root/.vcpkg"}"
+vcpkg_dir="$default_vcpkg_dir"
+install_deps=1
+triplets=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -d|--directory)
+      shift
+      [[ $# -gt 0 ]] || { echo "Missing argument for --directory" >&2; exit 1; }
+      vcpkg_dir="$1"
+      ;;
+    -t|--triplet)
+      shift
+      [[ $# -gt 0 ]] || { echo "Missing argument for --triplet" >&2; exit 1; }
+      triplets+=("$1")
+      ;;
+    --no-install)
+      install_deps=0
+      ;;
+    -h|--help)
+      print_usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      print_usage >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+mkdir -p "$(dirname "$vcpkg_dir")"
+
+if [[ ! -d "$vcpkg_dir/.git" ]]; then
+  echo "Cloning vcpkg into $vcpkg_dir"
+  git clone https://github.com/microsoft/vcpkg.git "$vcpkg_dir"
+else
+  echo "Updating existing vcpkg checkout in $vcpkg_dir"
+  git -C "$vcpkg_dir" pull --ff-only
+fi
+
+bootstrap_script="bootstrap-vcpkg.sh"
+uname_out="$(uname -s 2>/dev/null || echo)"
+case "$uname_out" in
+  MINGW*|MSYS*|CYGWIN*)
+    bootstrap_script="bootstrap-vcpkg.bat"
+    ;;
+  *)
+    ;;
+esac
+
+pushd "$vcpkg_dir" >/dev/null
+if [[ ! -x "$vcpkg_dir/vcpkg" ]]; then
+  echo "Bootstrapping vcpkg"
+  if [[ $bootstrap_script == *.bat ]]; then
+    if command -v cmd.exe >/dev/null 2>&1; then
+      cmd.exe /c "$bootstrap_script" -disableMetrics
+    else
+      echo "cmd.exe not available; cannot run $bootstrap_script" >&2
+      exit 1
+    fi
+  else
+    ./bootstrap-vcpkg.sh -disableMetrics
+  fi
+else
+  echo "vcpkg already bootstrapped"
+fi
+popd >/dev/null
+
+if [[ $install_deps -eq 1 ]]; then
+  if [[ ${#triplets[@]} -eq 0 ]]; then
+    case "$(uname -s 2>/dev/null || echo unknown)" in
+      Linux*)
+        triplets=("x64-linux")
+        ;;
+      Darwin*)
+        triplets=("x64-osx")
+        ;;
+      MINGW*|MSYS*|CYGWIN*)
+        triplets=("x64-windows")
+        ;;
+      *)
+        triplets=("x64-linux")
+        ;;
+    esac
+  fi
+  for triplet in "${triplets[@]}"; do
+    echo "Installing dependencies for triplet: $triplet"
+    "$vcpkg_dir/vcpkg" install --triplet "$triplet"
+  done
+fi
+
+echo "All done. Set VCPKG_ROOT=$vcpkg_dir or export it in your shell profile."


### PR DESCRIPTION
## Summary
- add bootstrap scripts under `tools/` to clone, bootstrap, and install vcpkg dependencies on Unix-like shells and PowerShell
- document the recommended developer environment setup in `docs/DEVELOPER_SETUP.md` and surface it from the README
- mark the roadmap item for developer setup as complete

## Testing
- ./tools/bootstrap_vcpkg.sh --help

------
https://chatgpt.com/codex/tasks/task_e_68dcc101dbe88321adaceca61727d48d