### PR TITLE
Add coordinator-aware GUI preview scaffolding

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -18,6 +18,7 @@ This document tracks the work required to deliver a modernized OpenTTD client de
 - [x] Port networking layer to OpenTTD 14.1 protocol changes.
 - [x] Update serialization/deserialization logic.
 - [ ] Implement GUI adjustments for new features.
+  - [x] Prototype coordinator-aware configuration panels in the client shell.
 - [ ] Ensure compatibility with dedicated server management tools.
 
 ## Phase 3 – Quality Assurance & Release

--- a/include/client_app.hpp
+++ b/include/client_app.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <chrono>
 #include <string>
 #include <vector>
+
+#include "network/coordinator_client.hpp"
 
 namespace sotc {
 
@@ -10,6 +13,14 @@ struct LaunchOptions {
     int server_port{3979};
     std::string player_name;
     bool headless{false};
+    network::ServerGameType server_game_type{network::ServerGameType::Public};
+    std::string invite_code{};
+    bool listed_publicly{true};
+    bool allow_direct{true};
+    bool allow_stun{true};
+    bool allow_turn{true};
+    std::chrono::seconds heartbeat_interval{std::chrono::seconds{30}};
+    std::vector<std::string> advertised_grfs{};
 };
 
 class ClientApp {
@@ -25,6 +36,7 @@ public:
 private:
     LaunchOptions options_{};
     void log_startup_info() const;
+    void render_gui_preview() const;
 };
 
 std::vector<std::string> discover_local_servers();

--- a/src/client_app.cpp
+++ b/src/client_app.cpp
@@ -5,11 +5,48 @@
 #include <cstdint>
 #include <iomanip>
 #include <iostream>
+#include <string_view>
 #include <thread>
 
 #include "network/coordinator_client.hpp"
 
 namespace sotc {
+
+namespace {
+
+[[nodiscard]] std::string_view to_string(network::ServerGameType type) {
+    using network::ServerGameType;
+    switch (type) {
+    case ServerGameType::Public:
+        return "Public";
+    case ServerGameType::FriendsOnly:
+        return "Friends only";
+    case ServerGameType::InviteOnly:
+        return "Invite only";
+    }
+    return "Unknown";
+}
+
+[[nodiscard]] std::string describe_nat_policy(const LaunchOptions &options) {
+    std::string description;
+    if (options.allow_direct) {
+        description += "Direct";
+    }
+    if (options.allow_stun) {
+        if (!description.empty()) description += ", ";
+        description += "STUN";
+    }
+    if (options.allow_turn) {
+        if (!description.empty()) description += ", ";
+        description += "TURN";
+    }
+    if (description.empty()) {
+        description = "None";
+    }
+    return description;
+}
+
+} // namespace
 
 ClientApp::ClientApp() = default;
 
@@ -19,6 +56,7 @@ void ClientApp::configure(LaunchOptions options) {
 
 void ClientApp::run() {
     log_startup_info();
+    render_gui_preview();
     std::cout << "Simple OpenTTD Client scaffold running." << std::endl;
     std::cout << "Networking and rendering subsystems are not yet implemented." << std::endl;
 
@@ -28,7 +66,14 @@ void ClientApp::run() {
                                   ? std::string{"Simple OpenTTD Client"}
                                   : options_.player_name + "'s game";
     registration.listen_port = static_cast<std::uint16_t>(options_.server_port);
-    registration.listed_publicly = !options_.headless;
+    registration.listed_publicly = options_.listed_publicly && !options_.headless;
+    registration.server_game_type = options_.server_game_type;
+    registration.invite_code = options_.invite_code;
+    registration.allow_direct = options_.allow_direct;
+    registration.allow_stun = options_.allow_stun;
+    registration.allow_turn = options_.allow_turn;
+    registration.heartbeat_interval = options_.heartbeat_interval;
+    registration.advertised_grfs = options_.advertised_grfs;
 
     auto frame = coordinator.build_registration_frame(registration);
     auto payload = frame.serialize();
@@ -72,7 +117,45 @@ void ClientApp::log_startup_info() const {
     std::cout << "  Server: " << (options_.server_host.empty() ? "<not set>" : options_.server_host)
               << ':' << options_.server_port << '\n';
     std::cout << "  Player: " << (options_.player_name.empty() ? "<anonymous>" : options_.player_name) << '\n';
-    std::cout << "  Headless: " << (options_.headless ? "yes" : "no") << std::endl;
+    std::cout << "  Headless: " << (options_.headless ? "yes" : "no") << '\n';
+    std::cout << "  Game type: " << to_string(options_.server_game_type) << '\n';
+    std::cout << "  Public listing: " << (options_.listed_publicly ? "yes" : "no") << '\n';
+    std::cout << "  Invite code: " << (options_.invite_code.empty() ? "<not set>" : options_.invite_code) << '\n';
+    std::cout << "  NAT: " << describe_nat_policy(options_) << '\n';
+    std::cout << "  Heartbeat: every " << options_.heartbeat_interval.count() << "s" << std::endl;
+}
+
+void ClientApp::render_gui_preview() const {
+    std::cout << "\n=== Session Configuration ===\n";
+    std::cout << "Player identity: "
+              << (options_.player_name.empty() ? "<anonymous>" : options_.player_name) << '\n';
+    std::cout << "Preferred server: "
+              << (options_.server_host.empty() ? "<not set>" : options_.server_host)
+              << ':' << options_.server_port << "\n\n";
+
+    std::cout << "[Server Visibility]\n";
+    std::cout << "  Game type: " << to_string(options_.server_game_type) << '\n';
+    std::cout << "  Listed on coordinator: " << (options_.listed_publicly ? "yes" : "no") << '\n';
+    if (!options_.invite_code.empty()) {
+        std::cout << "  Invite code: " << options_.invite_code << '\n';
+    } else {
+        std::cout << "  Invite code: <not set>\n";
+    }
+
+    std::cout << "\n[Connectivity]\n";
+    std::cout << "  Allowed pathways: " << describe_nat_policy(options_) << '\n';
+    std::cout << "  Coordinator heartbeat: every " << options_.heartbeat_interval.count() << "s\n";
+
+    std::cout << "\n[Advertised Content]\n";
+    if (options_.advertised_grfs.empty()) {
+        std::cout << "  No NewGRFs configured for advertising.\n";
+    } else {
+        for (const auto &grf_id : options_.advertised_grfs) {
+            std::cout << "  - " << grf_id << '\n';
+        }
+    }
+
+    std::cout << '\n';
 }
 
 std::vector<std::string> discover_local_servers() {


### PR DESCRIPTION
## Summary
- extend client launch options with coordinator visibility, invite, and NAT fields
- render a console-based configuration preview that reflects the new GUI elements
- capture the prototype work in the roadmap entry for Phase 2

## Testing
- cmake -S . -B build *(fails: missing SDL2 dependency in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcd91737708321839fde540a211f08