### PR TITLE
Add textual layout for coordinator GUI preview

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -19,6 +19,7 @@ This document tracks the work required to deliver a modernized OpenTTD client de
 - [x] Update serialization/deserialization logic.
 - [ ] Implement GUI adjustments for new features.
   - [x] Prototype coordinator-aware configuration panels in the client shell.
+  - [x] Render coordinator, access-control, and connectivity settings in the textual preview.
 - [ ] Ensure compatibility with dedicated server management tools.
 
 ## Phase 3 – Quality Assurance & Release

--- a/include/client_app.hpp
+++ b/include/client_app.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <chrono>
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -10,9 +11,11 @@ namespace sotc {
 
 struct LaunchOptions {
     std::string server_host;
-    int server_port{3979};
+    std::uint16_t server_port{network::NETWORK_DEFAULT_GAME_PORT};
     std::string player_name;
     bool headless{false};
+    std::string coordinator_host{"coordinator.openttd.org"};
+    std::uint16_t coordinator_port{network::NETWORK_COORDINATOR_SERVER_PORT};
     network::ServerGameType server_game_type{network::ServerGameType::Public};
     std::string invite_code{};
     bool listed_publicly{true};

--- a/include/gui/configuration_preview.hpp
+++ b/include/gui/configuration_preview.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace sotc::ui {
+
+struct FieldLine {
+    std::string label;
+    std::string value;
+};
+
+struct ToggleLine {
+    std::string label;
+    bool enabled{false};
+    std::string hint;
+};
+
+struct Section {
+    std::string title;
+    std::vector<FieldLine> fields;
+    std::vector<ToggleLine> toggles;
+    std::vector<std::string> notes;
+};
+
+[[nodiscard]] std::string render_sections(const std::vector<Section> &sections);
+
+} // namespace sotc::ui

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(sotc_core STATIC
     client_app.cpp
+    gui/configuration_preview.cpp
     network/coordinator_client.cpp
 )
 

--- a/src/gui/configuration_preview.cpp
+++ b/src/gui/configuration_preview.cpp
@@ -1,0 +1,71 @@
+#include "gui/configuration_preview.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <sstream>
+#include <string>
+
+namespace sotc::ui {
+namespace {
+
+[[nodiscard]] std::size_t compute_field_width(const Section &section) {
+    std::size_t width = 0;
+    for (const auto &field : section.fields) {
+        width = std::max(width, field.label.size());
+    }
+    if (width == 0) {
+        return 0;
+    }
+    // Room for trailing colon and a space.
+    return width + 2;
+}
+
+} // namespace
+
+std::string render_sections(const std::vector<Section> &sections) {
+    std::ostringstream stream;
+    bool first_section = true;
+    for (const auto &section : sections) {
+        if (!first_section) {
+            stream << '\n';
+        }
+        first_section = false;
+
+        stream << "=== " << section.title << " ===\n";
+
+        const auto field_width = compute_field_width(section);
+        for (const auto &field : section.fields) {
+            const std::string label = field.label + ':';
+            stream << "  " << label;
+            if (field_width > label.size()) {
+                stream << std::string(field_width - label.size(), ' ');
+            }
+            stream << field.value << '\n';
+        }
+
+        if (!section.fields.empty() && !section.toggles.empty()) {
+            stream << '\n';
+        }
+
+        for (const auto &toggle : section.toggles) {
+            stream << "  [" << (toggle.enabled ? 'x' : ' ') << "] " << toggle.label;
+            if (!toggle.hint.empty()) {
+                stream << " - " << toggle.hint;
+            }
+            stream << '\n';
+        }
+
+        if (!section.notes.empty()) {
+            if (!section.fields.empty() || !section.toggles.empty()) {
+                stream << '\n';
+            }
+            for (const auto &note : section.notes) {
+                stream << "  - " << note << '\n';
+            }
+        }
+    }
+
+    return stream.str();
+}
+
+} // namespace sotc::ui


### PR DESCRIPTION
## Summary
- extend `LaunchOptions` with coordinator endpoint fields and reuse them during registration and logging
- add a reusable textual GUI layout helper to render coordinator, access-control, and connectivity sections
- document the GUI preview progress in the roadmap

## Testing
- cmake -S . -B build *(fails: SDL2 package missing in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcdb5bb9e88321b736cdb3933abd64