### PR TITLE
Add quality assurance plan for Phase 3

### DIFF
--- a/docs/QUALITY_ASSURANCE_PLAN.md
+++ b/docs/QUALITY_ASSURANCE_PLAN.md
@@ -1,0 +1,76 @@
+# Quality Assurance Plan
+
+This document expands the Phase 3 roadmap items with actionable guidance so the
+team can stabilise the Simple OpenTTD Client and prepare a public release.
+
+## Automated Regression Tests
+
+The goal is to exercise a real OpenTTD 14.1 server using scripted scenarios.
+
+1. **Test harness**
+   - Use the existing Docker images from the OpenTTD project or package the
+     upstream dedicated server binaries inside a container image pinned to
+     14.1.
+   - Provide a CTest target (`ctest --label-regex integration`) that starts the
+     server in the background and executes the client with scripted inputs.
+   - Capture logs (`server.log`, `client.log`) and expose them as CTest
+     attachments for CI artefacts.
+2. **Coverage**
+   - Connection lifecycle (handshake, company join, graceful disconnect).
+   - Coordinator registration flows for `public`, `friends`, and `invite`
+     sessions, verifying payload schemas.
+   - Regression scenarios for configuration parsing (`--config` file, command
+     line overrides) to guarantee determinism.
+   - Negative cases: invalid invite code, unreachable coordinator, rejected
+     authentication.
+3. **CI Integration**
+   - Extend the existing GitHub Actions workflow to install the OpenTTD server
+     artefacts, run the labelled integration suite, and store the logs.
+   - Gate merges into the release branch on the automated suite.
+
+## Manual Gameplay Checklist
+
+Purpose: verify end-to-end playability, UI expectations, and behavioural
+regressions before cutting a release.
+
+- Launch the client in desktop mode, connect to a public server, and create a
+  company.
+- Validate UI panels: settings, coordinator options, company list, and message
+  console.
+- Play for 15 in-game years (fast-forward accepted) ensuring:
+  - vehicle purchasing, orders, servicing work without crashes;
+  - economy graphs render as expected;
+  - map tools (terraform, industries) respond promptly.
+- Repeat the session in headless mode and confirm the dedicated server exposes
+  correct metadata to the coordinator.
+- Sanity-check localisation strings in English and German (menus, tooltips,
+  status updates).
+- Record defects, screenshots, and reproduction steps in the issue tracker.
+
+## Windows Packaging
+
+- Produce two artefacts from the `Release` configuration:
+  - `SimpleOpenTTDClient-<version>-win64.zip` containing the binaries and
+    documentation.
+  - `SimpleOpenTTDClient-<version>-Setup.exe` built via `WiX` or `NSIS`, with
+    code-signing optional for internal builds.
+- Add a `tools/package_windows.ps1` script that automates the packaging steps
+  and collects dependent DLLs via `vcpkg` manifest inspection.
+- Verify the installer on a clean Windows VM (no Visual Studio runtime) and
+  document any prerequisite redistributables.
+
+## Release Notes & Documentation
+
+- Draft `docs/RELEASE_NOTES_<version>.md` summarising new features, known
+  issues, and upgrade considerations.
+- Update the main `README.md` with download links once binaries are hosted.
+- Prepare a `CHANGELOG.md` entry following Keep a Changelog format.
+- Announce availability on the project website or forum with clear upgrade
+  instructions and checksums.
+
+## Exit Criteria for Phase 3
+
+- All automated tests green in CI for at least two consecutive runs.
+- Manual checklist executed and signed off by two team members.
+- Windows packages uploaded and verified by testers.
+- Release notes published together with the binary artefacts.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -28,4 +28,7 @@ This document tracks the work required to deliver a modernized OpenTTD client de
 - [ ] Package Windows binaries (installer/ZIP).
 - [ ] Draft release notes and user documentation.
 
+Refer to `docs/QUALITY_ASSURANCE_PLAN.md` for detailed steps, coverage goals,
+and exit criteria for each item in this phase.
+
 Progress will be tracked via GitHub issues and milestone boards once the repository is published.


### PR DESCRIPTION
## Summary
- add a detailed quality assurance plan covering automated tests, manual checks, packaging, and release notes
- link the Phase 3 roadmap items to the new quality assurance plan for actionable guidance

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68dcfd78451c8321be30bdc167d9418d