### PR TITLE
Add integration tests for invalid CLI inputs

### DIFF
--- a/docs/QUALITY_ASSURANCE_PLAN.md
+++ b/docs/QUALITY_ASSURANCE_PLAN.md
@@ -38,6 +38,12 @@ file, applies CLI overrides, and asserts that both `--dump-launch-options` and
 schema. This provides early regression coverage for configuration parsing and
 payload generation while the full server-backed suite is being implemented.
 
+A companion script, `tests/integration/test_invalid_inputs.py`, exercises
+malformed heartbeat intervals and configuration flags to confirm the
+client exits with a failure status while emitting clear diagnostics.
+These checks seed the negative coverage required for Phase 3 while the
+server-backed scenarios are developed.
+
 ## Manual Gameplay Checklist
 
 Purpose: verify end-to-end playability, UI expectations, and behavioural

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -14,3 +14,16 @@ set_tests_properties(
     PROPERTIES
         LABELS "integration"
 )
+
+add_test(
+    NAME integration.invalid_inputs
+    COMMAND ${Python3_EXECUTABLE} ${SOTC_INTEGRATION_TEST_DIR}/test_invalid_inputs.py
+            --binary $<TARGET_FILE:sotc>
+)
+
+set_tests_properties(
+    integration.invalid_inputs
+    PROPERTIES
+        LABELS "integration"
+)
+

--- a/tests/integration/test_invalid_inputs.py
+++ b/tests/integration/test_invalid_inputs.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Integration tests validating error handling for invalid inputs.
+
+These checks exercise the client with intentionally malformed values to ensure
+it exits with a non-zero status and surfaces helpful diagnostics. They run
+without contacting live servers so they remain stable in continuous integration
+setups.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import subprocess
+import sys
+import tempfile
+import textwrap
+
+
+def run_client(binary: pathlib.Path, *args: str) -> subprocess.CompletedProcess[str]:
+    """Execute the client binary capturing stdout/stderr."""
+
+    command = [str(binary), *args]
+    return subprocess.run(
+        command,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def assert_failure(result: subprocess.CompletedProcess[str], message_fragment: str) -> None:
+    """Ensure the process failed and mentioned the expected diagnostic."""
+
+    if result.returncode == 0:
+        raise AssertionError(
+            f"Expected failure exit code but process succeeded.\n"
+            f"stdout: {result.stdout!r}\n"
+            f"stderr: {result.stderr!r}"
+        )
+    if message_fragment not in result.stderr:
+        raise AssertionError(
+            "Missing expected diagnostic in stderr.\n"
+            f"Expected fragment: {message_fragment!r}\n"
+            f"Actual stderr: {result.stderr!r}\n"
+            f"stdout: {result.stdout!r}"
+        )
+
+
+def test_invalid_heartbeat(binary: pathlib.Path) -> None:
+    result = run_client(binary, "--heartbeat", "-5", "--dump-launch-options")
+    assert_failure(result, "Invalid heartbeat interval")
+
+
+def test_invalid_config_flag(binary: pathlib.Path) -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config_path = pathlib.Path(tmpdir) / "sotc_invalid.cfg"
+        config_path.write_text(
+            textwrap.dedent(
+                """
+                # Invalid allow_stun value to trigger parse failure
+                allow_stun = maybe
+                """
+            ).strip()
+            + "\n",
+            encoding="utf-8",
+        )
+
+        result = run_client(binary, "--config", str(config_path), "--dump-launch-options")
+        assert_failure(result, "Invalid allow_stun value")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--binary", type=pathlib.Path, required=True, help="Path to the sotc client executable")
+    args = parser.parse_args()
+
+    test_invalid_heartbeat(args.binary)
+    test_invalid_config_flag(args.binary)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a Python integration test that verifies malformed heartbeat and configuration values fail with helpful diagnostics
- register the new script with CTest and document the additional coverage in the QA plan

## Testing
- not run (dependencies for SDL2/other third parties are unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd04835fac832188bd6df639732b46